### PR TITLE
Maybe fix issue 4?

### DIFF
--- a/syntax/nwtag.php
+++ b/syntax/nwtag.php
@@ -45,7 +45,7 @@ class syntax_plugin_wikiformatstyling_nwtag extends DokuWiki_Syntax_Plugin {
      * Create output
      */
     function render($format, Doku_Renderer $renderer, $data) {
-        if ( $data[1] == DOKU_LEXER_UNMATCHED ) {
+        if (is_array($data) && (count($data) > 1) && ($data[1] == DOKU_LEXER_UNMATCHED)) {
             $renderer->doc .= '<span class="wss-nowiki-section">' . hsc($data[0]) . '</span>';
         }
 

--- a/syntax/pcnt.php
+++ b/syntax/pcnt.php
@@ -45,7 +45,7 @@ class syntax_plugin_wikiformatstyling_pcnt extends DokuWiki_Syntax_Plugin {
      * Create output
      */
     function render($format, Doku_Renderer $renderer, $data) {
-        if ( $data[1] == DOKU_LEXER_UNMATCHED ) {
+        if (is_array($data) && (count($data) > 1) && ($data[1] == DOKU_LEXER_UNMATCHED)) {
             $renderer->doc .= '<span class="wss-nowiki-section">' . hsc($data[0]) . '</span>';
         }
 


### PR DESCRIPTION
Disclaimer: I do not use this plugin! It has only come to my attention because of the attempts by @rardcode to file an understandable issue in the correct place.

That said, the issue described in #4 (and previously in #3, https://github.com/linuxserver/docker-dokuwiki/issues/58 and https://github.com/splitbrain/dokuwiki/issues/3840) seems to be caused by an excessive number of PHP warnings which in turn are triggered in https://github.com/hokkaidoperson/DokuWiki-WikiFormatStyling-Plugin/blob/7189d24c0e73e14eadd7c604872e5e96a003c7e9/syntax/nwtag.php#L48 because apparently `$data` is `null` in some cases.

I do not have enough experience with the DokuWiki plugin API to really tell but I think this might be caused by the `handle()` method not always having a defined return value. This is just a guess though. This PR attempts to fix the results of this by checking `$data` before use in the `render()` method.

The same thing seems to be happening in https://github.com/hokkaidoperson/DokuWiki-WikiFormatStyling-Plugin/blob/7189d24c0e73e14eadd7c604872e5e96a003c7e9/syntax/pcnt.php#L48 so I applied the same fix there.

Please note that this is completely untested. So please check whether this works before merging or implement a better fix if possible.

HTH
fiwswe